### PR TITLE
Use sources section in Project.toml to avoid workflow failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,5 @@ jobs:
       # https://github.com/julia-actions/julia-runtest/blob/master/action.yml
       # in order to pass customised arguments to `Pkg.test()`
       - run: |
-          julia --check-bounds=yes --color=yes --depwarn=yes --project -e 'import Pkg; Pkg.add("https://github.com/moment-kinetics/LagrangePolynomials"); Pkg.test()'
+          julia --check-bounds=yes --color=yes --depwarn=yes --project -e 'import Pkg; Pkg.add(url="https://github.com/moment-kinetics/LagrangePolynomials"); Pkg.test()'
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,6 @@ jobs:
       # https://github.com/julia-actions/julia-runtest/blob/master/action.yml
       # in order to pass customised arguments to `Pkg.test()`
       - run: |
-          julia --check-bounds=yes --color=yes --depwarn=yes --project -e 'import Pkg; Pkg.add(PackageSpec(url="https://github.com/moment-kinetics/LagrangePolynomials")); Pkg.test()'
+          julia --project -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/moment-kinetics/LagrangePolynomials"))'
+          julia --check-bounds=yes --color=yes --depwarn=yes --project -e 'import Pkg; Pkg.test()'
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,5 @@ jobs:
       # https://github.com/julia-actions/julia-runtest/blob/master/action.yml
       # in order to pass customised arguments to `Pkg.test()`
       - run: |
-          julia --check-bounds=yes --color=yes --depwarn=yes --project -e 'import Pkg; Pkg.add(url="https://github.com/moment-kinetics/LagrangePolynomials"); Pkg.test()'
+          julia --check-bounds=yes --color=yes --depwarn=yes --project -e 'import Pkg; Pkg.add(PackageSpec(url="https://github.com/moment-kinetics/LagrangePolynomials")); Pkg.test()'
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,5 @@ jobs:
       # https://github.com/julia-actions/julia-runtest/blob/master/action.yml
       # in order to pass customised arguments to `Pkg.test()`
       - run: |
-          julia --project -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/moment-kinetics/LagrangePolynomials"))'
           julia --check-bounds=yes --color=yes --depwarn=yes --project -e 'import Pkg; Pkg.test()'
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,5 @@ jobs:
       # https://github.com/julia-actions/julia-runtest/blob/master/action.yml
       # in order to pass customised arguments to `Pkg.test()`
       - run: |
-          julia --check-bounds=yes --color=yes --depwarn=yes --project -e 'import Pkg; Pkg.test()'
+          julia --check-bounds=yes --color=yes --depwarn=yes --project -e 'import Pkg; Pkg.add("https://github.com/moment-kinetics/LagrangePolynomials"); Pkg.test()'
         shell: bash

--- a/Project.toml
+++ b/Project.toml
@@ -16,3 +16,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "FastGaussQuadrature", "LinearAlgebra"]
+
+[sources]
+LagrangePolynomials = {url="https://github.com/moment-kinetics/LagrangePolynomials"}


### PR DESCRIPTION
Julia 1.11 has the ability to record the source of unregistered packages in a section of the Project.toml https://pkgdocs.julialang.org/v1/toml-files/#The-%5Bsources%5D-section. This is used here to permit the use of the unregistered package LagrangePolynomials https://github.com/[moment-kinetics/LagrangePolynomials](https://github.com/moment-kinetics/LagrangePolynomials) in this project in the continuous integration tests. Other methods, such as manually using
```
using Pkg; Pkg.add(url="https://github.com/moment-kinetics/LagrangePolynomials")
```
did not resolve the package failure, which gave the error message below.
```
 Installing known registries into `~/.julia`
       Added `General` registry to ~/.julia/registries
    Updating registry at `~/.julia/registries/General.toml`
    Updating registry at `~/.julia/registries/General.toml`
ERROR: LoadError: expected package `LagrangePolynomials [fb83b288]` to be registered
``` 
